### PR TITLE
changed pip to pip3 because mypy requires >= Python3.5 version.

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -49,7 +49,7 @@ PyCharm, click on Python Console in the bottom left and type the following in:
 ```python
 import subprocess
 
-subprocess.check_call(["pip", "install", "mypy", "anki", "ankirspy", "aqt"])
+subprocess.check_call(["pip3", "install", "mypy", "anki", "ankirspy", "aqt"])
 ```
 
 Hit enter and wait. Once it completes, you should now have code completion. Try


### PR DESCRIPTION
While I was executing these 2 commands to create a new addon,

`import subprocess`

`subprocess.check_call(["pip", "install", "mypy", "anki", "ankirspy", "aqt"])`

 I received this error for mypy:

```
>>> subprocess.check_call(["pip", "install", "mypy", "anki", "ankirspy", "aqt"])
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
Defaulting to user installation because normal site-packages is not writeable
Collecting mypy
  Using cached mypy-0.720.tar.gz (1.9 MB)
    ERROR: Command errored out with exit status 1:
     command: /System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/4x/t35kkqtd61xfpx85m71y46d80000gn/T/pip-install-a2ORZ_/mypy/setup.py'"'"'; __file__='"'"'/private/var/folders/4x/t35kkqtd61xfpx85m71y46d80000gn/T/pip-install-a2ORZ_/mypy/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/4x/t35kkqtd61xfpx85m71y46d80000gn/T/pip-pip-egg-info-Jth9aa
         cwd: /private/var/folders/4x/t35kkqtd61xfpx85m71y46d80000gn/T/pip-install-a2ORZ_/mypy/
    Complete output (1 lines):
    ERROR: You need Python 3.5 or later to use mypy.
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "/usr/local/Cellar/python@3.8/3.8.5/Frameworks/Python.framework/Versions/3.8/lib/python3.8/subprocess.py", line 364, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['pip', 'install', 'mypy', 'anki', 'ankirspy', 'aqt']' returned non-zero exit status 1.
```
I used **pip3** instead of **pip** (pip is Python2. pip3 is Python3.) and it seemed to install **mypy** with no further issues.

However, I am having trouble recreating this issue as pip in future commands uses the already cached **mypy**

```
subprocess.check_call(["pip", "install", "mypy", "anki", "ankirspy", "aqt"])
Collecting mypy
  Using cached mypy-0.782-cp38-cp38-macosx_10_9_x86_64.whl (8.8 MB)
```

Hopefully, `subprocess.check_call(["pip3", "install", "mypy", "anki", "ankirspy", "aqt"])` should fix the issue.