### PR TITLE
a Japanese translation of the latest version

### DIFF
--- a/src/intro.md
+++ b/src/intro.md
@@ -2,7 +2,9 @@
 
 ## Translations
 
-- 日本語: <http://rs.luminousspice.com/ankiaddons21/>
+- 日本語: 
+  - <http://rs.luminousspice.com/ankiaddons21/>
+  - <https://t-cool.github.io/anki-addon-docs-ja/>
 
 ## Overview
 


### PR DESCRIPTION
The markdown files of addon-docs were exported to the site using mdbook and deployed on GitHub Pages. The Japanese version of the site will be updated according to changes in the official site.