### PR TITLE
Add links to Anki github repo for code references.

### DIFF
--- a/src/background-ops.md
+++ b/src/background-ops.md
@@ -86,7 +86,7 @@ A separate `CollectionOp` is provided for undoable operations that modify
 the collection. It functions similarly to QueryOp, but will also update the
 UI as changes are made (eg refresh the Browse screen if any notes are changed).
 
-Many undoable ops already have a `CollectionOp` defined in aqt/operations/\*.py.
+Many undoable ops already have a `CollectionOp` defined in [aqt/operations/\*.py](https://github.com/ankitects/anki/tree/main/qt/aqt/operations).
 You can often use one of them directly rather than having to create your own.
 For example:
 

--- a/src/hooks-and-filters.md
+++ b/src/hooks-and-filters.md
@@ -64,7 +64,7 @@ gui_hooks.reviewer_did_show_question.append(myfunc)
 ```
 
 An easy way to see all hooks at a glance is to look at
-pylib/tools/genhooks.py and qt/tools/genhooks_gui.py.
+[pylib/tools/genhooks.py](https://github.com/ankitects/anki/tree/main/pylib/tools/genhooks.py) and [qt/tools/genhooks_gui.py](https://github.com/ankitects/anki/blob/main/qt/tools/genhooks_gui.py).
 
 If you have set up type completion as described in an earlier section,
 you can also see the hooks in your IDE:
@@ -149,7 +149,7 @@ def onLeech(card):
 addHook("leech", onLeech)
 ```
 
-An example of a filter is in aqt/editor.py. The editor calls the
+An example of a filter is in [aqt/editor.py](https://github.com/ankitects/anki/blob/main/qt/aqt/editor.py). The editor calls the
 "editFocusLost" filter each time a field loses focus, so that add-ons
 can apply changes to the note:
 
@@ -243,8 +243,7 @@ addHook("setupEditorButtons", addMyButton)
 If you want to modify a function that doesn’t already have a hook,
 please submit a pull request that adds the hooks you need.
 
-The hook definitions are located in `pylib/tools/genhooks.py` and
-`qt/tools/genhooks_gui.py`. When building Anki, the build scripts will
+The hook definitions are located in [pylib/tools/genhooks.py](https://github.com/ankitects/anki/tree/main/pylib/tools/genhooks.py) and [qt/tools/genhooks_gui.py](https://github.com/ankitects/anki/blob/main/qt/tools/genhooks_gui.py).  When building Anki, the build scripts will
 automatically update the hook files with the definitions listed there.
 
-Please see the docs/ folder in the source tree for more information.
+Please see the [docs/](https://github.com/ankitects/anki/tree/main/docs) folder in the source tree for more information.

--- a/src/monkey-patching.md
+++ b/src/monkey-patching.md
@@ -14,9 +14,11 @@ Anki where adding new hooks would be impractical. In that case, you may
 unfortunately need to modify your add-on periodically as Anki is
 updated.
 
-In aqt/editor.py there is a function setupButtons() which creates the
-buttons like bold, italics and so on that you see in the editor. Let’s
-imagine you want to add another button in your add-on.
+In
+[aqt/editor.py](https://github.com/ankitects/anki/blob/main/qt/aqt/editor.py)
+there is a function setupButtons() which creates the buttons like
+bold, italics and so on that you see in the editor. Let’s imagine you
+want to add another button in your add-on.
 
 Anki 2.1 no longer uses setupButtons(). The code below is still useful
 to understand how monkey patching works, but for adding buttons to the

--- a/src/the-anki-module.md
+++ b/src/the-anki-module.md
@@ -1,7 +1,9 @@
 # The 'anki' Module
 
 All access to your collection and associated media go through a Python
-module called `anki`, located in `pylib/anki` in Anki's source repo.
+package called `anki`, located in
+[pylib/anki](https://github.com/ankitects/anki/tree/main/pylib/anki)
+in Anki's source repo.
 
 ## The Collection
 


### PR DESCRIPTION
I recently wrote my first add-on (thanks to these docs), and would have found it helpful to have direct links to the code when the docs referred to code in the Anki source repo.

This PR just changes references to links, eg: `defined in aqt/operations/\*.py.` becomes `defined in [aqt/operations/\*.py](https://github.com/ankitects/anki/tree/main/qt/aqt/operations).`

The only other change was the line "a Python module called anki, located in pylib/anki" -- this is actually a package, not a module.

Thank you very much!  If you don't wish to accept this PR, no harm done ... or let me know what fixes I need to make to the PR.

Cheers, jz