### PR TITLE
Should import showInfo and should use new card_count syntax

### DIFF
--- a/src/a-basic-addon.md
+++ b/src/a-basic-addon.md
@@ -5,22 +5,20 @@ Add the following to `myaddon/__init__.py` in your add-ons folder:
 ```python
 # import the main window object (mw) from aqt
 from aqt import mw
-
+# import the "show info" tool from utils.py
+from aqt.utils import showInfo, qconnect
 # import all of the Qt GUI library
 from aqt.qt import *
-
-# import showInfo from Anki utilities
-from aqt.utils import showInfo
 
 # We're going to add a menu item below. First we want to create a function to
 # be called when the menu item is activated.
 
 def testFunction() -> None:
-  # get the number of cards in the current collection, 
-  # which is stored in the main window
-  cardCount = mw.col.card_count()
-  # show a message box
-  showInfo("Card count: %d" % cardCount)
+    # get the number of cards in the current collection, which is stored in
+    # the main window
+    cardCount = mw.col.card_count()
+    # show a message box
+    showInfo("Card count: %d" % cardCount)
 
 # create a new menu item, "test"
 action = QAction("test", mw)

--- a/src/a-basic-addon.md
+++ b/src/a-basic-addon.md
@@ -5,20 +5,22 @@ Add the following to `myaddon/__init__.py` in your add-ons folder:
 ```python
 # import the main window object (mw) from aqt
 from aqt import mw
-# import the "show info" tool from utils.py
-from aqt.utils import showInfo, qconnect
+
 # import all of the Qt GUI library
 from aqt.qt import *
+
+# import showInfo from Anki utilities
+from aqt.utils import showInfo
 
 # We're going to add a menu item below. First we want to create a function to
 # be called when the menu item is activated.
 
 def testFunction() -> None:
-    # get the number of cards in the current collection, which is stored in
-    # the main window
-    cardCount = mw.col.cardCount()
-    # show a message box
-    showInfo("Card count: %d" % cardCount)
+  # get the number of cards in the current collection, 
+  # which is stored in the main window
+  cardCount = mw.col.card_count()
+  # show a message box
+  showInfo("Card count: %d" % cardCount)
 
 # create a new menu item, "test"
 action = QAction("test", mw)


### PR DESCRIPTION
I have Anki 25.02 installed (the latest release of the time of this pull request)

While trying to use the provided code sampl for creating a basic addon I had the following two errors:

1.  deprecated card_count

```sh
addons21/AI-Anki-Mass-Tagger/__init__.py:13:cardCount is deprecated: please use 'card_count'
Traceback (most recent call last):
```

Easy to fix, just switch to the new syntax.


2. showinfo not defined

```sh
Traceback (most recent call last):
  File "/Users/andrew/Library/Application Support/Anki2/addons21/AI-Anki-Mass-Tagger/__init__.py", line 14, in testFunction
    showInfo("Card count: %d" % cardCount)
NameError: name 'showInfo' is not defined
```

Another easy fix, just added the import.

## Testing.

I tested this on my MacOs 14.5 and Windows 11 and the new test code resolves the issues.
When I click the button with the updated code I can see the number of cards 

![Screenshot 2025-02-28 at 1 50 02 PM](https://github.com/user-attachments/assets/dd833e2e-1e4d-421c-be6c-390764baa3a1)
