### PR TITLE
Add details on how to initiate a collection and add a helper function in support of that.

### DIFF
--- a/src/the-anki-module.md
+++ b/src/the-anki-module.md
@@ -241,7 +241,7 @@ def get_collection_path(profile_name, attempts=0):
 
     # get dir - locations may be found at https://docs.ankiweb.net/files.html
     if system == 'Windows':
-        modern_dir =        f'{USER_PATH}/AppData/Roaming/%APPDATA%/Anki2/{profile_name}'
+        modern_dir =        f'{USER_PATH}/AppData/Roaming/Anki2/{profile_name}'
         old_dir =           f'{USER_PATH}/Documents/{profile_name}'
         profile_dir =       get_anki_dir(attempts, modern_dir, old_dir)
     elif system == 'Linux':

--- a/src/the-anki-module.md
+++ b/src/the-anki-module.md
@@ -8,12 +8,13 @@ in Anki's source repo.
 ## The Collection
 
 All operations on a collection file are accessed via a `Collection`
-object. The currently-open Collection is accessible via a global `mw.col`,
-where `mw` stands for `main window`. 
+object. 
 
-**Initiate collection from mw:**
+If running code inside an add-on, the Anki collection will be 
+accessible via the Anki main window, called `mw`, as shown below.
+
+**Access collection from mw:**
 ```python
-from anki.collection import ImportCsvRequest
 from aqt import mw
 
 
@@ -21,7 +22,7 @@ col = mw.col
 ```
 When using the `anki` module outside of Anki, the `mw` object will not exist.
 You will need to create your own `Collection` object 
-from `collection.anki2` ([see docs ]( https://docs.ankiweb.net/files.html) 
+from `collection.anki2` ([see docs]( https://docs.ankiweb.net/files.html) 
 or [use our helper function](#get-collection-path-helper-function)).
 
 **Initiate collection from file:**
@@ -30,14 +31,13 @@ from anki.collection import Collection
 
 
 profile_name = 'insert_your_profile_name'     # hint: default is 'User 1'
-# col_path = 'insert_manually'    # manual insertion
 col_path = get_collection_path(profile_name)  # using helper function 
 col = Collection(col_path)
 ```
 
 Some basic examples of what you can do with a collection follow. 
-With `mw` usage, please note that you should put
-these in something like [testFunction()](./a-basic-addon.md); you can’t run them
+With `mw` usage, please note that you should put its calls 
+in something like [testFunction()](./a-basic-addon.md); you can’t run them
 directly in an add-on, as add-ons are initialized during Anki startup, before
 any collection or profile has been loaded.
 

--- a/src/the-anki-module.md
+++ b/src/the-anki-module.md
@@ -22,16 +22,15 @@ col = mw.col
 ```
 When using the `anki` module outside of Anki, the `mw` object will not exist.
 You will need to create your own `Collection` object 
-from `collection.anki2` ([see docs]( https://docs.ankiweb.net/files.html) 
-or [use our helper function](#get-collection-path-helper-function)).
+from the `collection.anki2` file. The file can located via the [the docs](https://docs.ankiweb.net/files.html)
+or as shown below.
 
 **Initiate collection from file:**
 ```python
 from anki.collection import Collection
+from aqt.profiles import ProfileManager
 
-
-profile_name = 'insert_your_profile_name'     # hint: default is 'User 1'
-col_path = get_collection_path(profile_name)  # using helper function 
+col_path =  ProfileManager.get_created_base_folder(None)
 col = Collection(col_path)
 ```
 
@@ -221,43 +220,3 @@ If you need to store addon-specific data, consider using Anki’s
 If you need the data to sync across devices, small options can be stored
 within mw.col.conf. Please don’t store large amounts of data there, as
 it’s currently sent on every sync.
-
-**Get collection path helper function**
-```python
-import os
-import platform
-
-def get_collection_path(profile_name, attempts=0):
-    def get_anki_dir(attempts, *anki_dir_tuple):
-        anki_dir_tuple = anki_dir_tuple[attempts:]  # try progressively older locations
-        for path in anki_dir_tuple:
-            if os.path.exists(path):
-                return path
-        raise FileNotFoundError('No anki collection file not found in any of the searched directories.')
-
-    collection_anki2_filename = 'collection.anki2'
-    system = platform.system()
-    profile_dir = ''
-
-    # get dir - locations may be found at https://docs.ankiweb.net/files.html
-    if system == 'Windows':
-        modern_dir =        f'{USER_PATH}/AppData/Roaming/Anki2/{profile_name}'
-        old_dir =           f'{USER_PATH}/Documents/{profile_name}'
-        profile_dir =       get_anki_dir(attempts, modern_dir, old_dir)
-    elif system == 'Linux':
-        modern_collection = f'{USER_PATH}/.local/share/Anki2/{profile_name}'
-        old_collection =    f'{USER_PATH}/Documents/Anki/{profile_name}'
-        older_collection =  f'{USER_PATH}/Anki/{profile_name}'
-        profile_dir =       get_anki_dir(attempts, modern_collection, old_collection, older_collection)
-    elif system == 'Darwin':
-        modern_collection = f'{USER_PATH}/Library/Application Support/Anki2/{profile_name}'
-        old_collection =    f'{USER_PATH}/Documents/Anki/{profile_name}'
-        profile_dir =       get_anki_dir(attempts, modern_collection, old_collection)
-
-    # ensure file exists
-    path = f'{profile_dir}/{collection_anki2_filename}'
-    if not os.path.exists(path):
-        return get_collection_path(profile_name, attempts+1)
-
-    return path
-```


### PR DESCRIPTION
Pretty much what the title says.

For a fledgling Anki developer writing a non-add-on program, it is not obvious, even after reading mounds of source code and docs, that one can find and pass your collection.anki2 path to Collection() to initialize a col.

Anki Forums, Reddit, and unsolved PRs/Issues on 3rd party projects such as genanki, panki, and others are full of advanced users although perhaps new to Anki searching for (and at times unnecessarily and unknowingly trying to duplicate) functionality that already readily exists via the official module. They just can’t figure out how to use it without building an add-on.

I understand this is hosted on a domain with “addon” literally in the name, and this change doesn't directly impact Anki add-on development. However, it could be useful knowledge for add-on developers for testing. Also these docs are the only thorough documentation on Anki extensibility via its official module. I think educating users on working with collections with external scripts via the Anki module certainly falls under extensibility and provides a gateway to making Anki add-ons.

[Updated] Regarding the helper function, it has now been tested on Linux, Mac, and Windows.