### PR TITLE
Add link to Chinese translation of the tutorial

### DIFF
--- a/src/intro.md
+++ b/src/intro.md
@@ -5,6 +5,8 @@
 - 日本語: 
   - <https://t-cool.github.io/anki-addon-docs-ja/>
   - <http://rs.luminousspice.com/ankiaddons21/>
+- 中文：
+  - <https://zadenyip.github.io/addon-docs-zh/> 
 
 ## Overview
 


### PR DESCRIPTION
This pull request adds a link to a bilingual (English + Chinese) version of the tutorial.

- The bilingual version is hosted on my GitHub Pages.
- The content is based on the original English tutorial, translated into Chinese using Gemini-2.5-Pro and lightly proofread.
- Both the original English text and the Chinese translation are presented side by side.

This aims to help Chinese-speaking users better understand the tutorial while keeping the original English reference intact.

If you prefer a different placement for the link or would rather host the translation separately, I’d be happy to adjust.

这个 PR 在项目的教程介绍部分增加了一个超链接，指向我维护的双语版本的教程（英文原文 + 中文翻译）。
- 双语版本托管在我的 GitHub Pages 上。
- 翻译基于原始英文教程，由 Gemini-2.5-Pro 生成，并进行了人工的粗略校对。
- 页面采用英文原文和中文译文并列的形式，方便对照阅读。
这样做的目的是让中文读者更容易理解教程内容，同时保留英文原文作为参考。

如果您觉得链接的位置或呈现方式需要调整，我很乐意根据建议进行修改。