### PR TITLE
docs: update anki-console (fix # 435 in anki-manual)

### DIFF
--- a/src/console-output.md
+++ b/src/console-output.md
@@ -25,12 +25,20 @@ thousands of items), as that may slow Anki down, even if the console is not show
 
 ### Windows
 
-If you start Anki via the `anki-console.exe` file in `C:\Users\user\AppData\Local\Programs\Anki` (or `C:\Program Files\Anki`), a
+If you start Anki via the `anki-console.exe` file (or `anki-console.bat` file for Anki versions before 25.07) in `C:\Users\user\AppData\Local\Programs\Anki` (or `C:\Program Files\Anki`), a
 separate console window will appear.
 
 ### macOS
 
 Open Terminal.app, then enter the following text and hit enter:
+
+_For Anki 25.07 and later, paste_
+
+```
+/Applications/Anki.app/Contents/MacOS/launcher
+```
+
+_For Anki versions before 25.07, paste_
 
 ```
 /Applications/Anki.app/Contents/MacOS/anki

--- a/src/console-output.md
+++ b/src/console-output.md
@@ -32,13 +32,13 @@ separate console window will appear.
 
 Open Terminal.app, then enter the following text and hit enter:
 
-_For Anki 25.07 and later, paste_
+_For Anki 25.07 and later, enter_
 
 ```
 /Applications/Anki.app/Contents/MacOS/launcher
 ```
 
-_For Anki versions before 25.07, paste_
+_For Anki versions before 25.07, enter_
 
 ```
 /Applications/Anki.app/Contents/MacOS/anki

--- a/src/console-output.md
+++ b/src/console-output.md
@@ -25,8 +25,9 @@ thousands of items), as that may slow Anki down, even if the console is not show
 
 ### Windows
 
-If you start Anki via the `anki-console.exe` file (or `anki-console.bat` file for Anki versions before 25.07) in `C:\Users\user\AppData\Local\Programs\Anki` (or `C:\Program Files\Anki`), a
-separate console window will appear.
+If you start Anki via the `anki-console.exe` file (or `anki-console.bat` file for
+Anki versions before 25.07) in `%LocalAppData%\Programs\Anki` (or 
+`C:\Program Files\Anki`), a separate console window will appear.
 
 ### macOS
 

--- a/src/console-output.md
+++ b/src/console-output.md
@@ -25,7 +25,7 @@ thousands of items), as that may slow Anki down, even if the console is not show
 
 ### Windows
 
-If you start Anki via the `anki-console.bat` file in `C:\Users\user\AppData\Local\Programs\Anki` (or `C:\Program Files\Anki`), a
+If you start Anki via the `anki-console.exe` file in `C:\Users\user\AppData\Local\Programs\Anki` (or `C:\Program Files\Anki`), a
 separate console window will appear.
 
 ### macOS

--- a/src/console-output.md
+++ b/src/console-output.md
@@ -32,13 +32,13 @@ separate console window will appear.
 
 Open Terminal.app, then enter the following text and hit enter:
 
-_For Anki 25.07 and later, enter_
+For Anki 25.07 and later, enter
 
 ```
 /Applications/Anki.app/Contents/MacOS/launcher
 ```
 
-_For Anki versions before 25.07, enter_
+For Anki versions before 25.07, enter
 
 ```
 /Applications/Anki.app/Contents/MacOS/anki

--- a/src/console-output.md
+++ b/src/console-output.md
@@ -25,8 +25,8 @@ thousands of items), as that may slow Anki down, even if the console is not show
 
 ### Windows
 
-If you start Anki via the `anki-console.exe` file (or `anki-console.bat` file for
-Anki versions before 25.07) in `%LocalAppData%\Programs\Anki` (or 
+If you start Anki via the `anki-console.exe` file (or `anki-console.bat` file
+for Anki versions before 25.07) in `%LocalAppData%\Programs\Anki` (or 
 `C:\Program Files\Anki`), a separate console window will appear.
 
 ### macOS


### PR DESCRIPTION
This PR updates the [Startup Issues](https://docs.ankiweb.net/platform/windows/startup-issues.html) and [Console Output](https://addon-docs.ankiweb.net/console-output.html#windows) documentation to reflect changes introduced in Anki 25.07 and later. So the changes replaced references to `anki-console.bat` with `anki-console.exe`. 

Link for the PR for [anki-manual PR](https://github.com/ankitects/anki-manual/pull/458).

Fixes issue [# 435](https://github.com/ankitects/anki-manual/issues/435) in anki-manual